### PR TITLE
remove trailing slashes from the array keys

### DIFF
--- a/wpmg-widget.php
+++ b/wpmg-widget.php
@@ -41,19 +41,19 @@ class wpmg_list extends WP_Widget {
 
 	public function get_meetups() {
 		$meetups = array(
-			'https://wpmeetup-berlin.de/' => array( 'title' => 'Berlin', 'url' => 'https://wpmeetup-berlin.de/' ),
-			'http://wpmeetup-dresden.de/' => array( 'title' => 'Dresden', 'url' => 'http://wpmeetup-dresden.de/' ),
-			'http://www.wpmeetup-eifel.de/' => array( 'title' => 'Eifel', 'url' => 'http://www.wpmeetup-eifel.de/' ),
-			'http://wpmeetup-franken.de/' => array( 'title' => 'Franken', 'url' => 'http://wpmeetup-franken.de/' ),
-			'http://wpmeetup-frankfurt.de/' => array( 'title' => 'Frankfurt', 'url' => 'http://wpmeetup-frankfurt.de/' ),
-			'http://wpmeetup-hamburg.de/' => array( 'title' => 'Hamburg', 'url' => 'http://wpmeetup-hamburg.de/' ),
-			'http://www.wpmeetup-hannover.de/' => array( 'title' => 'Hannover', 'url' => 'http://www.wpmeetup-hannover.de/' ),
-			'http://wpcgn.de/' => array( 'title' => 'Köln', 'url' => 'http://wpcgn.de/' ),
-			'http://wpmeetup-karlsruhe.de/' => array( 'title' => 'Karlsruhe', 'url' => 'http://wpmeetup-karlsruhe.de/' ),
-			'http://wpmeetup-muenchen.org/' => array( 'title' => 'München', 'url' => 'http://wpmeetup-muenchen.org/' ),
-			'http://www.wpmeetup-osnabrueck.de/' => array( 'title' => 'Osnabrück/Münster/Emsland', 'url' => 'http://www.wpmeetup-osnabrueck.de/' ),
-			'http://wpmeetup-potsdam.de/' => array( 'title' => 'Potsdam', 'url' => 'http://wpmeetup-potsdam.de/' ),
-			'http://wpmeetup-stuttgart.de/' => array( 'title' => 'Stuttgart', 'url' => 'http://wpmeetup-stuttgart.de/' ),
+			'https://wpmeetup-berlin.de' => array( 'title' => 'Berlin', 'url' => 'https://wpmeetup-berlin.de/' ),
+			'http://wpmeetup-dresden.de' => array( 'title' => 'Dresden', 'url' => 'http://wpmeetup-dresden.de/' ),
+			'http://www.wpmeetup-eifel.de' => array( 'title' => 'Eifel', 'url' => 'http://www.wpmeetup-eifel.de/' ),
+			'http://wpmeetup-franken.de' => array( 'title' => 'Franken', 'url' => 'http://wpmeetup-franken.de/' ),
+			'http://wpmeetup-frankfurt.de' => array( 'title' => 'Frankfurt', 'url' => 'http://wpmeetup-frankfurt.de/' ),
+			'http://wpmeetup-hamburg.de' => array( 'title' => 'Hamburg', 'url' => 'http://wpmeetup-hamburg.de/' ),
+			'http://www.wpmeetup-hannover.de' => array( 'title' => 'Hannover', 'url' => 'http://www.wpmeetup-hannover.de/' ),
+			'http://wpcgn.de' => array( 'title' => 'Köln', 'url' => 'http://wpcgn.de/' ),
+			'http://wpmeetup-karlsruhe.de' => array( 'title' => 'Karlsruhe', 'url' => 'http://wpmeetup-karlsruhe.de/' ),
+			'http://wpmeetup-muenchen.org' => array( 'title' => 'München', 'url' => 'http://wpmeetup-muenchen.org/' ),
+			'http://www.wpmeetup-osnabrueck.de' => array( 'title' => 'Osnabrück/Münster/Emsland', 'url' => 'http://www.wpmeetup-osnabrueck.de/' ),
+			'http://wpmeetup-potsdam.de' => array( 'title' => 'Potsdam', 'url' => 'http://wpmeetup-potsdam.de/' ),
+			'http://wpmeetup-stuttgart.de' => array( 'title' => 'Stuttgart', 'url' => 'http://wpmeetup-stuttgart.de/' ),
 		);
 
 		$siteurl = site_url();


### PR DESCRIPTION
The `site_url()` function returns the `siteurl` option without a trailing slash, so it has to be removed in order to filter the current meetup page out.
