### PR TITLE
change URL to HH Meetup so the make filter work

### DIFF
--- a/wpmg-widget.php
+++ b/wpmg-widget.php
@@ -51,7 +51,7 @@ class wpmg_list extends WP_Widget {
 			'http://www.wpmeetup-eifel.de' => array( 'title' => 'Eifel', 'url' => 'http://www.wpmeetup-eifel.de/' ),
 			'https://wpmeetup-franken.de' => array( 'title' => 'Franken', 'url' => 'https://wpmeetup-franken.de/' ),
 			'https://wpmeetup-frankfurt.de' => array( 'title' => 'Frankfurt', 'url' => 'https://wpmeetup-frankfurt.de/' ),
-			'https://www.wpmeetup-hamburg.de/' => array( 'title' => 'Hamburg', 'url' => 'https://wpmeetup-hamburg.de/' ),
+			'https://www.wpmeetup-hamburg.de' => array( 'title' => 'Hamburg', 'url' => 'https://www.wpmeetup-hamburg.de/' ),
 			'http://www.wpmeetup-hannover.de' => array( 'title' => 'Hannover', 'url' => 'http://www.wpmeetup-hannover.de/' ),
 			'http://wpmeetup-karlsruhe.de' => array( 'title' => 'Karlsruhe', 'url' => 'http://wpmeetup-karlsruhe.de/' ),
 			'http://wpcgn.de' => array( 'title' => 'Köln', 'url' => 'http://wpcgn.de/' ),


### PR DESCRIPTION
site_url() returns the url without the / at the end. The url of the HH Meetup was including it, so the check failed. 

fixes #11
