### PR TITLE
Koblenz and URL fix

### DIFF
--- a/wpmg-widget.php
+++ b/wpmg-widget.php
@@ -21,7 +21,7 @@ GitHub Branch: master
 Copyright 2015 WP Meetup Frankfurt (wpfra.de) (e-mail: kontakt@wpfra.de)
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License, version 2, as 
+it under the terms of the GNU General Public License, version 2, as
 published by the Free Software Foundation.
 
 This program is distributed in the hope that it will be useful,
@@ -45,30 +45,30 @@ class wpmg_list extends WP_Widget {
 	public function get_meetups() {
 		$meetups = array(
 			'https://www.meetup.com/de-DE/Aachen-WordPress-Meetup/' => array( 'title' => 'Aachen', 'url' => 'https://www.meetup.com/de-DE/Aachen-WordPress-Meetup/' ),
-			'https://wpmeetup-berlin.de' => array( 'title' => 'Berlin', 'url' => 'https://wpmeetup-berlin.de/' ),
-			'https://wpbern.ch' => array( 'title' => 'Bern', 'url' => 'https://wpbern.ch/' ),
-			'https://www.wpbn.de' => array( 'title' => 'Bonn', 'url' => 'https://www.wpbn.de' ),
-			'https://wpmeetup-bremen.de' => array( 'title' => 'Bremen', 'url' => 'https://wpmeetup-bremen.de/' ),
-			'http://wpmeetup-dresden.de' => array( 'title' => 'Dresden', 'url' => 'http://wpmeetup-dresden.de/' ),
-			'https://www.meetup.com/de-DE/Dusseldorf-WordPress-Meetup/' => array( 'title' => 'Düsseldorf', 'url' => 'https://www.meetup.com/de-DE/Dusseldorf-WordPress-Meetup//' ),
-			'http://www.wpmeetup-eifel.de' => array( 'title' => 'Eifel', 'url' => 'http://www.wpmeetup-eifel.de/' ),
-			'https://wpmeetup-franken.de' => array( 'title' => 'Franken', 'url' => 'https://wpmeetup-franken.de/' ),
-			'https://wpmeetup-frankfurt.de' => array( 'title' => 'Frankfurt', 'url' => 'https://wpmeetup-frankfurt.de/' ),
-			'https://www.wpmeetup-hamburg.de' => array( 'title' => 'Hamburg', 'url' => 'https://www.wpmeetup-hamburg.de/' ),
-			'http://wpmeetup-hannover.de' => array( 'title' => 'Hannover', 'url' => 'http://wpmeetup-hannover.de/' ),
-			'http://wpmeetup-karlsruhe.de' => array( 'title' => 'Karlsruhe', 'url' => 'http://wpmeetup-karlsruhe.de/' ),
-			'https://wpkoblenz.de' => array( 'title' => 'Karlsruhe', 'url' => 'https://wpkoblenz.de' ),
-			'https://wpcgn.de' => array( 'title' => 'Köln', 'url' => 'https://wpcgn.de/' ),
-			'https://wpmeetupleipzig.wordpress.com' => array( 'title' => 'Leipzig', 'url' => 'https://wpmeetupleipzig.wordpress.com' ),
-			'https://wpmeetup-muenchen.org' => array( 'title' => 'München', 'url' => 'https://wpmeetup-muenchen.org/' ),
-			'http://www.wpmeetup-osnabrueck.de' => array( 'title' => 'Osnabrück/Münster/Emsland', 'url' => 'http://www.wpmeetup-osnabrueck.de/' ),
-			'https://wpmeetup-paderborn.de' => array( 'title' => 'Paderborn', 'url' => 'https://wpmeetup-paderborn.de/' ),
-			'https://wpmeetup-potsdam.de' => array( 'title' => 'Potsdam', 'url' => 'https://wpmeetup-potsdam.de/' ),
-			'https://www.meetup.com/de-DE/WordPress-Meetup-Region-38/' => array( 'title' => 'Region 38', 'url' => 'https://www.meetup.com/de-DE/WordPress-Meetup-Region-38//' ),
-			'https://wpmeetup.saarland' => array( 'title' => 'Saarland', 'url' => 'https://wpmeetup.saarland/' ),
-			'https://wpmeetupstuttgart.de' => array( 'title' => 'Stuttgart', 'url' => 'https://wpmeetupstuttgart.de/' ),
-			'https://wpmeetup-wuerzburg.de' => array( 'title' => 'Würzburg', 'url' => 'https://wpmeetup-wuerzburg.de/' ),
-			'https://www.meetup.com/de/wordpress-zurich' => array( 'title' => 'Zürich', 'url' => 'https://www.meetup.com/de/wordpress-zurich/' ),
+			'https://wpmeetup-berlin.de/' => array( 'title' => 'Berlin', 'url' => 'https://wpmeetup-berlin.de/' ),
+			'https://wpbern.ch/' => array( 'title' => 'Bern', 'url' => 'https://wpbern.ch/' ),
+			'https://www.wpbn.de/' => array( 'title' => 'Bonn', 'url' => 'https://www.wpbn.de/' ),
+			'https://wpmeetup-bremen.de/' => array( 'title' => 'Bremen', 'url' => 'https://wpmeetup-bremen.de/' ),
+			'http://wpmeetup-dresden.de/' => array( 'title' => 'Dresden', 'url' => 'http://wpmeetup-dresden.de/' ),
+			'https://www.meetup.com/de-DE/Dusseldorf-WordPress-Meetup/' => array( 'title' => 'Düsseldorf', 'url' => 'https://www.meetup.com/de-DE/Dusseldorf-WordPress-Meetup/' ),
+			'http://www.wpmeetup-eifel.de/' => array( 'title' => 'Eifel', 'url' => 'http://www.wpmeetup-eifel.de/' ),
+			'https://wpmeetup-franken.de/' => array( 'title' => 'Franken', 'url' => 'https://wpmeetup-franken.de/' ),
+			'https://wpmeetup-frankfurt.de/' => array( 'title' => 'Frankfurt', 'url' => 'https://wpmeetup-frankfurt.de/' ),
+			'https://www.wpmeetup-hamburg.de/' => array( 'title' => 'Hamburg', 'url' => 'https://www.wpmeetup-hamburg.de/' ),
+			'http://wpmeetup-hannover.de/' => array( 'title' => 'Hannover', 'url' => 'http://wpmeetup-hannover.de/' ),
+			'http://wpmeetup-karlsruhe.de/' => array( 'title' => 'Karlsruhe', 'url' => 'http://wpmeetup-karlsruhe.de/' ),
+			'https://wpkoblenz.de/' => array( 'title' => 'Koblenz', 'url' => 'https://wpkoblenz.de/' ),
+			'https://wpcgn.de/' => array( 'title' => 'Köln', 'url' => 'https://wpcgn.de/' ),
+			'https://wpmeetupleipzig.wordpress.com/' => array( 'title' => 'Leipzig', 'url' => 'https://wpmeetupleipzig.wordpress.com/' ),
+			'https://wpmeetup-muenchen.org/' => array( 'title' => 'München', 'url' => 'https://wpmeetup-muenchen.org/' ),
+			'http://www.wpmeetup-osnabrueck.de/' => array( 'title' => 'Osnabrück/Münster/Emsland', 'url' => 'http://www.wpmeetup-osnabrueck.de/' ),
+			'https://wpmeetup-paderborn.de/' => array( 'title' => 'Paderborn', 'url' => 'https://wpmeetup-paderborn.de/' ),
+			'https://wpmeetup-potsdam.de/' => array( 'title' => 'Potsdam', 'url' => 'https://wpmeetup-potsdam.de/' ),
+			'https://www.meetup.com/de-DE/WordPress-Meetup-Region-38/' => array( 'title' => 'Region 38', 'url' => 'https://www.meetup.com/de-DE/WordPress-Meetup-Region-38/' ),
+			'https://wpmeetup.saarland/' => array( 'title' => 'Saarland', 'url' => 'https://wpmeetup.saarland/' ),
+			'https://wpmeetupstuttgart.de/' => array( 'title' => 'Stuttgart', 'url' => 'https://wpmeetupstuttgart.de/' ),
+			'https://wpmeetup-wuerzburg.de/' => array( 'title' => 'Würzburg', 'url' => 'https://wpmeetup-wuerzburg.de/' ),
+			'https://www.meetup.com/de/wordpress-zurich/' => array( 'title' => 'Zürich', 'url' => 'https://www.meetup.com/de/wordpress-zurich/' ),
 		);
 
 		return $meetups;


### PR DESCRIPTION
URL cleanup with ending slash and fixed city name for Koblenz - was Karlsruhe before